### PR TITLE
feat: add TypeScript-to-Lua type declarations

### DIFF
--- a/.github/workflows/ts-types.yml
+++ b/.github/workflows/ts-types.yml
@@ -1,0 +1,31 @@
+name: TS Types
+
+on:
+  push:
+    branches: [main]
+    paths: ["ts-types/**", "package.json", "biome.json"]
+  pull_request:
+    branches: [main]
+    paths: ["ts-types/**", "package.json", "biome.json"]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run test:types
+
+      - name: Lint & format
+        run: npx biome check ts-types/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ luac.out
 # Coverage
 luacov.*.out
 luacov_report.html*
+
+# Node
+node_modules/
+package-lock.json

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off",
+        "noParameterAssign": "error",
+        "useDefaultParameterLast": "error",
+        "noUnusedTemplateLiteral": "error",
+        "noUselessElse": "error"
+      },
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "noUnusedFunctionParameters": "error"
+      },
+      "suspicious": {
+        "noConsole": "warn"
+      },
+      "performance": {
+        "noNamespaceImport": "error"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": { "quoteStyle": "double", "semicolons": "always" }
+  },
+  "files": {
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/*.lua"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,14 +2,24 @@
   "name": "luamark-types",
   "version": "1.0.1",
   "description": "TypeScript-to-Lua type declarations for luamark",
-  "types": "index.d.ts",
-  "files": ["**/*.d.ts"],
+  "types": "ts-types/index.d.ts",
+  "files": [
+    "ts-types/**/*.d.ts"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/jeffzi/luamark"
   },
+  "scripts": {
+    "test:types": "tsc --noEmit -p ts-types/tsconfig.test-types.json"
+  },
   "peerDependencies": {
     "typescript-to-lua": ">=1.30.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.4.4",
+    "expect-type": "^1.0.0",
+    "typescript": "^5.4.0"
   }
 }

--- a/ts-types/index.d.ts
+++ b/ts-types/index.d.ts
@@ -1,0 +1,111 @@
+/** @noSelfInFile */
+/// <reference types="@typescript-to-lua/language-extensions" />
+
+declare module "luamark" {
+  type ParamValue = string | number | boolean;
+
+  interface BaseStats {
+    readonly median: number;
+    readonly ci_lower: number;
+    readonly ci_upper: number;
+    readonly ci_margin: number;
+    readonly total: number;
+    readonly samples: readonly number[];
+    readonly relative?: number;
+    readonly rank?: number;
+  }
+
+  interface Stats extends BaseStats {
+    readonly rounds: number;
+    readonly iterations: number;
+    readonly timestamp: string;
+    readonly unit: "s" | "kb";
+    readonly ops?: number;
+    readonly is_approximate?: boolean;
+  }
+
+  interface Result extends BaseStats {
+    readonly name: string;
+    readonly rounds: number;
+    readonly iterations: number;
+    readonly timestamp: string;
+    readonly unit: "s" | "kb";
+    readonly ops?: number;
+    readonly is_approximate?: boolean;
+    readonly params: Record<string, ParamValue>;
+  }
+
+  interface Options {
+    rounds?: number;
+    time?: number;
+    setup?: (this: void) => unknown;
+    teardown?: (this: void, ctx?: unknown) => void;
+  }
+
+  interface SuiteOptions {
+    rounds?: number;
+    time?: number;
+    setup?: (this: void, params: Record<string, ParamValue>) => unknown;
+    teardown?: (this: void, ctx: unknown, params: Record<string, ParamValue>) => void;
+    params?: Record<string, ParamValue[]>;
+  }
+
+  interface Spec {
+    fn: (this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void;
+    before?: (this: void, ctx?: unknown, params?: Record<string, ParamValue>) => unknown;
+    after?: (this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void;
+    baseline?: boolean;
+  }
+
+  interface Timer {
+    start(this: void): void;
+    stop(this: void): number;
+    elapsed(this: void): number;
+    reset(this: void): void;
+  }
+
+  // Mutable config
+  let rounds: number;
+  let time: number;
+
+  // Readonly config
+  const clock_name: string;
+  const _VERSION: string;
+
+  // Functions
+  function timeit(
+    this: void,
+    fn: (this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void,
+    opts?: Options,
+  ): Stats;
+
+  function memit(
+    this: void,
+    fn: (this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void,
+    opts?: Options,
+  ): Stats;
+
+  function compare_time(
+    this: void,
+    funcs: Record<string, ((this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void) | Spec>,
+    opts?: SuiteOptions,
+  ): Result[];
+
+  function compare_memory(
+    this: void,
+    funcs: Record<string, ((this: void, ctx?: unknown, params?: Record<string, ParamValue>) => void) | Spec>,
+    opts?: SuiteOptions,
+  ): Result[];
+
+  function Timer(this: void): Timer;
+
+  function render(this: void, results: Stats | Result[], short?: boolean, max_width?: number): string;
+
+  function humanize_time(this: void, s: number): string;
+
+  function humanize_memory(this: void, kb: number): string;
+
+  function humanize_count(this: void, n: number): string;
+
+  function unload(this: void, pattern: string): number;
+}

--- a/ts-types/package.json
+++ b/ts-types/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "luamark-types",
+  "version": "1.0.1",
+  "description": "TypeScript-to-Lua type declarations for luamark",
+  "types": "index.d.ts",
+  "files": ["**/*.d.ts"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jeffzi/luamark"
+  },
+  "peerDependencies": {
+    "typescript-to-lua": ">=1.30.0"
+  }
+}

--- a/ts-types/test/generics.test-d.ts
+++ b/ts-types/test/generics.test-d.ts
@@ -1,0 +1,153 @@
+import { expectTypeOf } from "expect-type";
+import type { Options, Result, Spec, Stats, SuiteOptions } from "luamark";
+import { compare_memory, compare_time, memit, render, timeit } from "luamark";
+
+// ---------------------------------------------------------------------------
+// timeit / memit — Ctx inference from setup
+// ---------------------------------------------------------------------------
+
+// Ctx inferred as string[] from setup return type
+timeit(
+  (ctx) => {
+    expectTypeOf(ctx).toEqualTypeOf<string[]>();
+  },
+  { setup: () => ["a", "b"] },
+);
+
+// Ctx defaults to unknown when no opts provided
+timeit((ctx) => {
+  expectTypeOf(ctx).toBeUnknown();
+});
+
+// memit infers Ctx the same way
+memit(
+  (ctx) => {
+    expectTypeOf(ctx).toEqualTypeOf<number>();
+  },
+  { setup: () => 42 },
+);
+
+// teardown receives the same Ctx
+timeit(() => {}, {
+  setup: () => ({ count: 0 }),
+  teardown: (ctx) => {
+    expectTypeOf(ctx).toEqualTypeOf<{ count: number }>();
+  },
+});
+
+// ---------------------------------------------------------------------------
+// compare_time / compare_memory — Ctx + P inference
+// ---------------------------------------------------------------------------
+
+// P inferred from params config
+const results = compare_time(
+  { my_fn: (_ctx, params) => expectTypeOf(params.n).toBeNumber() },
+  { params: { n: [10, 100] } },
+);
+
+// Result carries inferred P
+expectTypeOf(results[0]!.params.n).toBeNumber();
+
+// Ctx inferred from setup (no params → P defaults)
+compare_time(
+  {
+    my_fn: (ctx) => {
+      expectTypeOf(ctx).toEqualTypeOf<string[]>();
+    },
+  },
+  { setup: () => ["a", "b"] },
+);
+
+// Both Ctx and P inferred together
+compare_time(
+  {
+    my_fn: (ctx, params) => {
+      expectTypeOf(ctx).toEqualTypeOf<number[]>();
+      expectTypeOf(params.n).toBeNumber();
+    },
+  },
+  {
+    params: { n: [10, 100] },
+    setup: () => [1, 2, 3],
+  },
+);
+
+// compare_memory works the same way
+compare_memory(
+  { my_fn: (_ctx, params) => expectTypeOf(params.label).toBeString() },
+  { params: { label: ["a", "b"] } },
+);
+
+// ---------------------------------------------------------------------------
+// Spec interface
+// ---------------------------------------------------------------------------
+
+// Spec with explicit generics
+const spec: Spec<string[], { n: number }> = {
+  fn: (ctx, params) => {
+    expectTypeOf(ctx).toEqualTypeOf<string[]>();
+    expectTypeOf(params.n).toBeNumber();
+  },
+  before: (ctx, params) => {
+    expectTypeOf(ctx).toEqualTypeOf<string[]>();
+    expectTypeOf(params.n).toBeNumber();
+    return ctx; // before can return Ctx
+  },
+  after: (ctx, _params) => {
+    expectTypeOf(ctx).toEqualTypeOf<string[]>();
+  },
+  baseline: true,
+};
+
+// before can also return void (Lua: iteration_ctx = before(ctx, p) or ctx)
+const _specVoidBefore: Spec<string[], { n: number }> = {
+  fn: () => {},
+  before: () => {}, // returns void — valid
+};
+
+// Spec used in compare functions
+compare_time({ test: spec }, { params: { n: [1, 2, 3] }, setup: () => ["hello"] });
+
+// ---------------------------------------------------------------------------
+// Options / SuiteOptions interfaces
+// ---------------------------------------------------------------------------
+
+// Defaults work (Ctx = unknown, P = Record<string, string | number | boolean>)
+const _defaultOpts: Options = { rounds: 10 };
+const _defaultSuiteOpts: SuiteOptions = { rounds: 10 };
+
+// Mapped params type: each key maps to an array of its value type
+const _typedSuiteOpts: SuiteOptions<unknown, { n: number; label: string }> = {
+  params: {
+    n: [1, 2, 3],
+    label: ["a", "b"],
+  },
+};
+
+// Verify wrong element type is rejected
+const _badParams: SuiteOptions<unknown, { n: number }> = {
+  // @ts-expect-error — string[] is not assignable to number[]
+  params: { n: ["not a number"] },
+};
+
+// ---------------------------------------------------------------------------
+// render accepts Result[] with any P (covariant)
+// ---------------------------------------------------------------------------
+
+const typedResults: Result<{ n: number }>[] = [];
+render(typedResults); // Result<{n: number}> assignable to Result (default P)
+
+// render also accepts Stats
+render({} as Stats);
+
+// ---------------------------------------------------------------------------
+// Result interface
+// ---------------------------------------------------------------------------
+
+// Result with default P
+const defaultResult: Result = {} as Result;
+expectTypeOf(defaultResult.params).toEqualTypeOf<Record<string, string | number | boolean>>();
+
+// Result with specific P
+const typedResult: Result<{ n: number }> = {} as Result<{ n: number }>;
+expectTypeOf(typedResult.params.n).toBeNumber();

--- a/ts-types/tsconfig.test-types.json
+++ b/ts-types/tsconfig.test-types.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["index.d.ts", "test/**/*.test-d.ts"]
+}


### PR DESCRIPTION
Generic `.d.ts` declarations for luamark's API so TypeScript infers concrete `ctx` and `params` types from `setup()` return values and params config — no casts needed.